### PR TITLE
Fix TileLang link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This experimental release represents our ongoing research into more efficient tr
 
 ## Open-Source Kernels
 
-For TileLang kernels with **better readability and research-purpose design**, please refer to [TileLang](https://github.com/tile-ai/tilelang/tree/main/examples/deepseek-v32).
+For TileLang kernels with **better readability and research-purpose design**, please refer to [TileLang](https://github.com/tile-ai/tilelang/tree/main/examples/deepseek_v32).
 
 For **high-performance CUDA kernels**, indexer logit kernels (including paged versions) are available in [DeepGEMM](https://github.com/deepseek-ai/DeepGEMM/pull/200). Sparse attention kernels are released in [FlashMLA](https://github.com/deepseek-ai/FlashMLA/pull/98).
 


### PR DESCRIPTION
The TileLang link was pointing to `deepseek-v32`, but in actuality it's `deepseek_v32`.