### PR TITLE
Finetune sglang launching command

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ docker pull lmsysorg/sglang:dsv32-a3
 
 #### Launch Command
 ```bash
-python -m sglang.launch_server --model deepseek-ai/DeepSeek-V3.2-Exp --tp 8 --dp 8 --page-size 64
+python -m sglang.launch_server --model deepseek-ai/DeepSeek-V3.2-Exp --tp 8 --dp 8 --enable-dp-attention
 ```
 
 ### vLLM


### PR DESCRIPTION
The `--page-size` should be adjusted inside the server, which is related to the backend auto-choosing mechanism. Instead We explictly to show the dp attention support in the command.