### PR TITLE
Indexer: Add a non TileLang version and fix broadcast for world_size=1

### DIFF
--- a/inference/model.py
+++ b/inference/model.py
@@ -934,4 +934,3 @@ if __name__ == "__main__":
     args = ModelArgs()
     x = torch.randint(0, args.vocab_size, (2, 128))
     model = Transformer(args)
-    print(model(x).size())

--- a/inference/model.py
+++ b/inference/model.py
@@ -934,3 +934,4 @@ if __name__ == "__main__":
     args = ModelArgs()
     x = torch.randint(0, args.vocab_size, (2, 128))
     model = Transformer(args)
+    print(model(x).size())


### PR DESCRIPTION
- Add support for a pure pytorch Indexer (in bf16) without dependency on TileLang.
- Fix Indexer broadcast for non-distributed runs (`world_size=1`)